### PR TITLE
Set 404 error code when using custom handler.

### DIFF
--- a/bone.go
+++ b/bone.go
@@ -143,6 +143,7 @@ func (m *Mux) NotFound(handler http.HandlerFunc) {
 // Handle the bad request
 func (m *Mux) BadRequest(rw http.ResponseWriter, req *http.Request) {
 	if m.notFound != nil {
+		rw.WriteHeader(http.StatusNotFound)
 		m.notFound(rw, req)
 	} else {
 		http.NotFound(rw, req)

--- a/bone_test.go
+++ b/bone_test.go
@@ -24,6 +24,22 @@ func TestRouting(t *testing.T) {
 	}
 }
 
+// Test the custom not handler handler sets 404 error code
+func TestNotFoundCustomHandlerSends404(t *testing.T) {
+	mux := New()
+	mux.NotFound(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Write([]byte("These are not the droids you're looking for ..."))
+	})
+
+	r, _ := http.NewRequest("GET", "/b/123", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, r)
+
+	if w.Code != 404 {
+		t.Errorf("expecting error code 404, got %v", w.Code)
+	}
+}
+
 // Test if the http method is valid
 func TestRoutingMethod(t *testing.T) {
 	mux := New()


### PR DESCRIPTION
When using a custom not found handler, the http status code is not set to 404.
