### PR TITLE
Renaming BadRequest to HandleNotFound

### DIFF
--- a/bone.go
+++ b/bone.go
@@ -65,7 +65,7 @@ func (m *Mux) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		}
 		continue
 	}
-	m.BadRequest(rw, req)
+	m.HandleNotFound(rw, req)
 }
 
 // Handle add a new route to the Mux without a HTTP method

--- a/helper.go
+++ b/helper.go
@@ -13,8 +13,8 @@ import (
 	"net/url"
 )
 
-// BadRequest handle every wring request.
-func (m *Mux) BadRequest(rw http.ResponseWriter, req *http.Request) {
+// Handle when a request does not match a registered handler.
+func (m *Mux) HandleNotFound(rw http.ResponseWriter, req *http.Request) {
 	if m.notFound != nil {
 		rw.WriteHeader(http.StatusNotFound)
 		m.notFound(rw, req)


### PR DESCRIPTION
Renaming BadRequest to HandleNotFound since the request isn't really 'bad' (i.e. not a 400), but missing a request handler.