### PR TITLE
fix match race condition with vars map

### DIFF
--- a/route.go
+++ b/route.go
@@ -95,14 +95,14 @@ func (r *Route) Match(req *http.Request) bool {
 
 	if r.matchRawTokens(&ss) {
 		if len(ss) == r.Token.Size || r.Atts&WC != 0 {
+			vars.Lock()
 			if vars.v[req] == nil {
-				vars.Lock()
 				vars.v[req] = make(map[string]string)
-				vars.Unlock()
 			}
 			for k, v := range r.Pattern {
 				vars.v[req][v] = ss[k]
 			}
+			vars.Unlock()
 			if r.Atts&REGEX != 0 {
 				for k, v := range r.Compile {
 					if !v.MatchString(ss[k]) {


### PR DESCRIPTION
Since Go 1.6 race condition is better detected. 

> fatal error: concurrent map read and map write
> fatal error: concurrent map read and map write
> 
> goroutine 10105 [running]:
> runtime.throw(0xa6a2c0, 0x21)
>         C:/Go/src/runtime/panic.go:530 +0x97 fp=0xc0820639c8 sp=0xc0820639b0
> runtime.mapaccess1_fast64(0x86ed40, 0xc082052c90, 0xc082126540, 0x1)
>         C:/Go/src/runtime/hashmap_fast.go:112 +0x61 fp=0xc0820639e8 sp=0xc0820639c8
> local/beenote/vendor/github.com/go-zoo/bone.(*Route).Match(0xc08214c500, 0xc082126540, 0x9e6700)
>         C:/Workspace/src/local/beenote/vendor/github.com/go-zoo/bone/route.go:98 +0x121 fp=0xc082063b58 sp=0xc0820639e8
> local/beenote/vendor/github.com/go-zoo/bone.(*Route).parse(0xc08214c500, 0x2a44338, 0xc082122060, 0xc082126540, 0xc082049100)
>         C:/Workspace/src/local/beenote/vendor/github.com/go-zoo/bone/route.go:133 +0x196 fp=0xc082063bc0 sp=0xc082063b58