### PR TITLE
Write '404 Not Found' status code in header when mux custom 404 handler is used

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -44,6 +44,7 @@ func (m *Mux) staticRoute(rw http.ResponseWriter, req *http.Request) bool {
 // HandleNotFound handle when a request does not match a registered handler.
 func (m *Mux) HandleNotFound(rw http.ResponseWriter, req *http.Request) {
 	if m.notFound != nil {
+        rw.WriteHeader(http.StatusNotFound)
 		m.notFound.ServeHTTP(rw, req)
 	} else {
 		http.NotFound(rw, req)


### PR DESCRIPTION
Added rw.WriteHeader(http.StatusNotFound) on HandleNotFound handler.