### PR TITLE
This PR adds proper handling of redirects for paths ending in '/'.

### DIFF
--- a/bone_test.go
+++ b/bone_test.go
@@ -397,18 +397,32 @@ func TestWC(t *testing.T) {
 	}
 }
 
-func TestSlashRemoving(t *testing.T) {
-	valid := false
+func TestSlashRemoving1(t *testing.T) {
 	mux := New()
 	mux.GetFunc("/test", func(rw http.ResponseWriter, req *http.Request) {
-		valid = true
+		t.Error("/test got called but it should have been a redirect!")
 	})
 
 	req, _ := http.NewRequest("GET", "/test/////", nil)
 	rw := httptest.NewRecorder()
 	mux.ServeHTTP(rw, req)
 
-	if !valid {
-		t.Error("Slash removing doesn't work !")
+	if rw.Header().Get("Location") != "/test" {
+		t.Error("Redirect 1 doesn't work")
+	}
+}
+
+func TestSlashRemovingWithQuery(t *testing.T) {
+	mux := New()
+	mux.GetFunc("/test", func(rw http.ResponseWriter, req *http.Request) {
+		t.Error("/test got called but it should have been a redirect!")
+	})
+
+	req, _ := http.NewRequest("GET", "/test/?foo=bar&buzz=bazz", nil)
+	rw := httptest.NewRecorder()
+	mux.ServeHTTP(rw, req)
+
+	if rw.Header().Get("Location") != "/test?foo=bar&buzz=bazz" {
+		t.Error("Redirect 2 doesn't work")
 	}
 }

--- a/helper.go
+++ b/helper.go
@@ -60,8 +60,9 @@ func (m *Mux) validate(rw http.ResponseWriter, req *http.Request) bool {
 	plen := len(req.URL.Path)
 	if plen > 1 && req.URL.Path[plen-1:] == "/" {
 		cleanURL(&req.URL.Path)
-		rw.Header().Set("Location", req.URL.Path)
+		rw.Header().Set("Location", req.URL.String())
 		rw.WriteHeader(http.StatusFound)
+		return true
 	}
 	// Retry to find a route that match
 	return m.parse(rw, req)


### PR DESCRIPTION
I was running into a problem where a request to my server that looked like `"http://my.server.com/path/?a=foo&b=bar"` was being redirected to `"http://my.server.com/path"` -- but also returning results from the first query. 

There were two bugs:

* A redirect should return a 302 ("Found") and NOT process the
request.

* A redirect should set the Location header to the full redirect URL,
not just the path (it should include any query parameters as well). This
is because a redirect can actually rewrite the query parameters if it
wants to.

The test for slash removal has been changed to indicate this.
