### PR TITLE
go 1.7 context

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ func Handler(rw http.ResponseWriter, req *http.Request) {
 ```
 ## Changelog
 
+#### Update 10 September 2016
+
+- Add support for go1.7 net.Context
+
 #### Update 25 September 2015
 
 - Add support for Sub router

--- a/bone.go
+++ b/bone.go
@@ -10,7 +10,6 @@ package bone
 import (
 	"net/http"
 	"strings"
-	"sync"
 )
 
 // Mux have routes and a notFound handler
@@ -25,10 +24,6 @@ type Mux struct {
 var (
 	static = "static"
 	method = []string{"GET", "POST", "PUT", "DELETE", "HEAD", "PATCH", "OPTIONS"}
-	vars   = struct {
-		sync.RWMutex
-		v map[*http.Request]map[string]string
-	}{v: make(map[*http.Request]map[string]string)}
 )
 
 // New create a pointer to a Mux instance

--- a/bone_context_test.go
+++ b/bone_context_test.go
@@ -1,0 +1,41 @@
+// +build go1.7
+
+package bone
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRoutingVariableWithContext(t *testing.T) {
+	var (
+		expected = "variable"
+		got      string
+		mux      = New()
+		w        = httptest.NewRecorder()
+	)
+
+	appFn := func(w http.ResponseWriter, r *http.Request) {
+		got = GetValue(r, "vartest")
+	}
+
+	middlewareFn := func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), "key", "customValue")
+		newReq := r.WithContext(ctx)
+		appFn(w, newReq)
+	}
+
+	mux.Get("/:vartest", http.HandlerFunc(middlewareFn))
+	r, err := http.NewRequest("GET", fmt.Sprintf("/%s", expected), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mux.ServeHTTP(w, r)
+
+	if got != expected {
+		t.Fatalf("expected %s, got %s", expected, got)
+	}
+}

--- a/bone_test.go
+++ b/bone_test.go
@@ -1,6 +1,7 @@
 package bone
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -269,6 +270,36 @@ func TestRoutingVariable(t *testing.T) {
 		got = GetValue(r, "vartest")
 	}))
 
+	r, err := http.NewRequest("GET", fmt.Sprintf("/%s", expected), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mux.ServeHTTP(w, r)
+
+	if got != expected {
+		t.Fatalf("expected %s, got %s", expected, got)
+	}
+}
+
+func TestRoutingVariableWithContext(t *testing.T) {
+	var (
+		expected = "variable"
+		got      string
+		mux      = New()
+		w        = httptest.NewRecorder()
+	)
+
+	appFn := func(w http.ResponseWriter, r *http.Request) {
+		got = GetValue(r, "vartest")
+	}
+
+	middlewareFn := func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), "key", "customValue")
+		newReq := r.WithContext(ctx)
+		appFn(w, newReq)
+	}
+
+	mux.Get("/:vartest", http.HandlerFunc(middlewareFn))
 	r, err := http.NewRequest("GET", fmt.Sprintf("/%s", expected), nil)
 	if err != nil {
 		t.Fatal(err)

--- a/bone_test.go
+++ b/bone_test.go
@@ -1,7 +1,6 @@
 package bone
 
 import (
-	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -270,36 +269,6 @@ func TestRoutingVariable(t *testing.T) {
 		got = GetValue(r, "vartest")
 	}))
 
-	r, err := http.NewRequest("GET", fmt.Sprintf("/%s", expected), nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	mux.ServeHTTP(w, r)
-
-	if got != expected {
-		t.Fatalf("expected %s, got %s", expected, got)
-	}
-}
-
-func TestRoutingVariableWithContext(t *testing.T) {
-	var (
-		expected = "variable"
-		got      string
-		mux      = New()
-		w        = httptest.NewRecorder()
-	)
-
-	appFn := func(w http.ResponseWriter, r *http.Request) {
-		got = GetValue(r, "vartest")
-	}
-
-	middlewareFn := func(w http.ResponseWriter, r *http.Request) {
-		ctx := context.WithValue(r.Context(), "key", "customValue")
-		newReq := r.WithContext(ctx)
-		appFn(w, newReq)
-	}
-
-	mux.Get("/:vartest", http.HandlerFunc(middlewareFn))
 	r, err := http.NewRequest("GET", fmt.Sprintf("/%s", expected), nil)
 	if err != nil {
 		t.Fatal(err)

--- a/helper.go
+++ b/helper.go
@@ -91,16 +91,6 @@ func GetValue(req *http.Request, key string) string {
 	return GetAllValues(req)[key]
 }
 
-// GetAllValues return the req PARAMs
-func GetAllValues(req *http.Request) map[string]string {
-	values, ok := req.Context().Value(contextKey).(map[string]string)
-	if ok {
-		return values
-	}
-
-	return map[string]string{}
-}
-
 // This function returns the route of given Request
 func (m *Mux) GetRequestRoute(req *http.Request) string {
 	cleanURL(&req.URL.Path)

--- a/helper.go
+++ b/helper.go
@@ -103,7 +103,7 @@ func (m *Mux) GetRequestRoute(req *http.Request) string {
 					}
 				}
 			}
-			if ok, _ := r.Match(req); ok {
+			if r.Match(req) {
 				return r.Path
 			}
 		}

--- a/helper.go
+++ b/helper.go
@@ -88,18 +88,17 @@ func cleanURL(url *string) {
 
 // GetValue return the key value, of the current *http.Request
 func GetValue(req *http.Request, key string) string {
-	vars.RLock()
-	value := vars.v[req][key]
-	vars.RUnlock()
-	return value
+	return GetAllValues(req)[key]
 }
 
 // GetAllValues return the req PARAMs
 func GetAllValues(req *http.Request) map[string]string {
-	vars.RLock()
-	values := vars.v[req]
-	vars.RUnlock()
-	return values
+	values, ok := req.Context().Value(contextKey).(map[string]string)
+	if ok {
+		return values
+	}
+
+	return map[string]string{}
 }
 
 // This function returns the route of given Request
@@ -114,7 +113,7 @@ func (m *Mux) GetRequestRoute(req *http.Request) string {
 					}
 				}
 			}
-			if r.Match(req) {
+			if ok, _ := r.Match(req); ok {
 				return r.Path
 			}
 		}

--- a/helper_15.go
+++ b/helper_15.go
@@ -1,0 +1,40 @@
+// +build !go1.7
+
+/********************************
+*** Multiplexer for Go        ***
+*** Bone is under MIT license ***
+*** Code by CodingFerret      ***
+*** github.com/go-zoo         ***
+*********************************/
+
+package bone
+
+import (
+	"net/http"
+	"sync"
+)
+
+var globalVars = struct {
+	sync.RWMutex
+	v map[*http.Request]map[string]string
+}{v: make(map[*http.Request]map[string]string)}
+
+// GetAllValues return the req PARAMs
+func GetAllValues(req *http.Request) map[string]string {
+	globalVars.RLock()
+	values := globalVars.v[req]
+	globalVars.RUnlock()
+	return values
+}
+
+// serveMatchedRequest is an extension point for Route which allows us to conditionally compile for
+// go1.7 and <go1.7
+func (r *Route) serveMatchedRequest(rw http.ResponseWriter, req *http.Request, vars map[string]string) {
+	globalVars.Lock()
+	globalVars.v[req] = vars
+	globalVars.Unlock()
+	r.Handler.ServeHTTP(rw, req)
+	globalVars.Lock()
+	delete(globalVars.v, req)
+	globalVars.Unlock()
+}

--- a/helper_17.go
+++ b/helper_17.go
@@ -1,0 +1,39 @@
+// +build go1.7
+
+/********************************
+*** Multiplexer for Go        ***
+*** Bone is under MIT license ***
+*** Code by CodingFerret      ***
+*** github.com/go-zoo         ***
+*********************************/
+
+package bone
+
+import (
+	"context"
+	"net/http"
+)
+
+// contextKeyType is a private struct that is used for storing bone values in net.Context
+type contextKeyType struct{}
+
+// contextKey is the key that is used to store bone values in the net.Context for each request
+var contextKey = contextKeyType{}
+
+// GetAllValues return the req PARAMs
+func GetAllValues(req *http.Request) map[string]string {
+	values, ok := req.Context().Value(contextKey).(map[string]string)
+	if ok {
+		return values
+	}
+
+	return map[string]string{}
+}
+
+// serveMatchedRequest is an extension point for Route which allows us to conditionally compile for
+// go1.7 and <go1.7
+func (r *Route) serveMatchedRequest(rw http.ResponseWriter, req *http.Request, vars map[string]string) {
+	ctx := context.WithValue(req.Context(), contextKey, vars)
+	newReq := req.WithContext(ctx)
+	r.Handler.ServeHTTP(rw, newReq)
+}

--- a/route.go
+++ b/route.go
@@ -89,9 +89,15 @@ func (r *Route) save() {
 	}
 }
 
-// Match check if the request matches the route Pattern and returns a map of the parsed variables
-// if it matches
-func (r *Route) Match(req *http.Request) (bool, map[string]string) {
+// Match check if the request match the route Pattern
+func (r *Route) Match(req *http.Request) bool {
+	ok, _ := r.matchAndParse(req)
+	return ok
+}
+
+// matchAndParse check if the request matches the route Pattern and returns a map of the parsed
+// variables if it matches
+func (r *Route) matchAndParse(req *http.Request) (bool, map[string]string) {
 	ss := strings.Split(req.URL.EscapedPath(), "/")
 	if r.matchRawTokens(&ss) {
 		if len(ss) == r.Token.Size || r.Atts&WC != 0 {
@@ -133,7 +139,7 @@ func (r *Route) parse(rw http.ResponseWriter, req *http.Request) bool {
 			}
 		}
 
-		if ok, vars := r.Match(req); ok {
+		if ok, vars := r.matchAndParse(req); ok {
 			r.serveMatchedRequest(rw, req, vars)
 			return true
 		}

--- a/route.go
+++ b/route.go
@@ -8,7 +8,6 @@
 package bone
 
 import (
-	"context"
 	"net/http"
 	"regexp"
 	"strings"
@@ -49,12 +48,6 @@ type Token struct {
 	Tokens []string
 	Size   int
 }
-
-// contextKeyType is a private struct that is used for storing bone values in net.Context
-type contextKeyType struct{}
-
-// contextKey is the key that is used to store bone values in the net.Context for each request
-var contextKey = contextKeyType{}
 
 // NewRoute return a pointer to a Route instance and call save() on it
 func NewRoute(url string, h http.Handler) *Route {
@@ -141,9 +134,7 @@ func (r *Route) parse(rw http.ResponseWriter, req *http.Request) bool {
 		}
 
 		if ok, vars := r.Match(req); ok {
-			ctx := context.WithValue(req.Context(), contextKey, vars)
-			newReq := req.WithContext(ctx)
-			r.Handler.ServeHTTP(rw, newReq)
+			r.serveMatchedRequest(rw, req, vars)
 			return true
 		}
 	}


### PR DESCRIPTION
Refactor value storage to use net.Context.   This allows users of bone to use `http.Request.WithContext` without bone breaking.

I also expect this to have performance benefits since the map of requests has been completely eliminated (and locking is no longer required, since we don't allow mutations of the request values).