### PR TITLE
Support for 405 HTTP Status Code, Method Not Allowed.

### DIFF
--- a/bone.go
+++ b/bone.go
@@ -56,7 +56,10 @@ func (m *Mux) DefaultServe(rw http.ResponseWriter, req *http.Request) {
 		if !m.staticRoute(rw, req) {
 			// Check if the request path doesn't end with /
 			if !m.validate(rw, req) {
-				m.HandleNotFound(rw, req)
+				// Check if same route exists for another HTTP method
+				if !m.otherMethods(rw, req) {
+					m.HandleNotFound(rw, req)
+				}
 			}
 		}
 	}

--- a/helper.go
+++ b/helper.go
@@ -156,3 +156,18 @@ func extractQueries(req *http.Request) (bool, map[string][]string) {
 	}
 	return false, nil
 }
+
+func (m *Mux) otherMethods(rw http.ResponseWriter, req *http.Request) bool {
+	for _, met := range method {
+		if met != req.Method {
+			for _, r := range m.Routes[met] {
+				ok := r.exists(rw, req)
+				if ok {
+					rw.WriteHeader(http.StatusMethodNotAllowed)
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/helper_test.go
+++ b/helper_test.go
@@ -328,3 +328,37 @@ func Test_extractQueries(t *testing.T) {
 		})
 	}
 }
+
+func TestMux_otherMethods(t *testing.T) {
+	type fields struct {
+		Routes   map[string][]*Route
+		prefix   string
+		notFound http.Handler
+		Serve    func(rw http.ResponseWriter, req *http.Request)
+	}
+	type args struct {
+		rw  http.ResponseWriter
+		req *http.Request
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   bool
+	}{
+	// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &Mux{
+				Routes:   tt.fields.Routes,
+				prefix:   tt.fields.prefix,
+				notFound: tt.fields.notFound,
+				Serve:    tt.fields.Serve,
+			}
+			if got := m.otherMethods(tt.args.rw, tt.args.req); got != tt.want {
+				t.Errorf("Mux.otherMethods() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/route.go
+++ b/route.go
@@ -170,6 +170,26 @@ func (r *Route) matchRawTokens(ss *[]string) bool {
 	return false
 }
 
+func (r *Route) exists(rw http.ResponseWriter, req *http.Request) bool {
+	if r.Atts != 0 {
+		if r.Atts&SUB != 0 {
+			if len(req.URL.Path) >= r.Size {
+				if req.URL.Path[:r.Size] == r.Path {
+					return true
+				}
+			}
+		}
+
+		if ok, _ := r.matchAndParse(req); ok {
+			return true
+		}
+	}
+	if req.URL.Path == r.Path {
+		return true
+	}
+	return false
+}
+
 // Get set the route method to Get
 func (r *Route) Get() *Route {
 	r.Method = "GET"


### PR DESCRIPTION
Solves issue #60 and #37.

First checking requested method and it's registered routes if the route not found for the requested method, then instead of returning 404 instantly, it checks all other methods for the same request path. 