### PR TITLE
Change RegisterValidator to RegisterValidatorFunc in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ import(
 func main () {
   mux := bone.New()
 
-  mux.RegisterValidator("isNum", func(s string) bool {
+  mux.RegisterValidatorFunc("isNum", func(s string) bool {
     if _, err := strconv.Atoi(s); err == nil {
       return true
     }


### PR DESCRIPTION
The example in the README.md file wouldn't compile as RegisterValidator expects an interface of the type Validator. Registering the function with RegisterValidatorFunc allows registering a func literal.