### PR TITLE
Support Go Modules

### DIFF
--- a/example/003/go.mod
+++ b/example/003/go.mod
@@ -1,0 +1,12 @@
+module github.com/go-zoo/bone/example/003
+
+go 1.9
+
+require (
+	github.com/go-zoo/bone v0.0.0
+	github.com/gorilla/context v1.1.1 // indirect
+	github.com/gorilla/mux v1.6.2
+	github.com/julienschmidt/httprouter v1.2.0
+)
+
+replace github.com/go-zoo/bone v0.0.0 => ../../

--- a/example/003/go.sum
+++ b/example/003/go.sum
@@ -1,0 +1,6 @@
+github.com/gorilla/context v1.1.1 h1:AWwleXJkX/nhcU9bZSnZoi3h/qGYqQAGhq6zZe/aQW8=
+github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
+github.com/gorilla/mux v1.6.2 h1:Pgr17XVTNXAk3q/r4CpKzC5xBM/qW1uVLV+IhRZpIIk=
+github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/julienschmidt/httprouter v1.2.0 h1:TDTW5Yz1mjftljbcKqRcrYhd4XeOoI98t+9HbQbYf7g=
+github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/go-zoo/bone
+
+go 1.9


### PR DESCRIPTION
Hello,

Please consider supporting [Go Modules], the new packaging standard that will be on by default Go 1.12. Experimental support is in Go 1.11 and the new module paths are supported in Go 1.9.7+ and Go 1.10.3+ in a read-only manner for backwards compatibility with all supported versions of Go.

Because this library is still below version 2, and has no external dependencies, the [`go.mod`] file is fairly simple. If you accept this PR, the only other thing to do would be to start using semver compatible tags and tag a release of this library that others can pin to (for example `v1.2.1`).

Note that I set the language version go 1.9 in the mod file because 1.9.7 is the earliest version with partial support for reading the `go.mod` file (earlier versions will keep working as they always have and won't read the go.mod file) and it did not appear that you were using any standard library or language features introduced after 1.9 (it builds fine with 1.9.7). Naturally this can change if you only support a later version of Go.

Using modules if future changes are made to this library is relatively simple; `go get -u` on Go 1.11 with modules on or 1.12 by default will update dependencies (not a problem here), and `go mod tidy` will trim down any dependencies that have been removed (or add any new dependencies it finds). I'd be happy to provide more information, or a quick crash course in using modules if you want to familiarize yourself with them.

The second `go.mod` file in the examples it just to stop the main package from pulling in httprouter and gorilla as dependencies when they're only needed by examples.

Thank you for your consideration.

[Go Modules]: https://github.com/golang/go/wiki/Modules
[`go.mod`]: https://tip.golang.org/cmd/go/#hdr-The_go_mod_file